### PR TITLE
feat: make cleanup of work dir optional

### DIFF
--- a/docs/data/data.yaml
+++ b/docs/data/data.yaml
@@ -139,6 +139,13 @@ properties:
     type: string
     required: false
 
+  - name: cleanup
+    description: |
+      Delete the working directory after the git action.
+    type: bool
+    defaultValue: true
+    required: false
+
   - name: remote_url
     description: |
       Url of the remote repository.

--- a/git/git.go
+++ b/git/git.go
@@ -19,6 +19,7 @@ type Repository struct {
 	ForcePush      bool
 	WorkDir        string
 	IsEmpty        bool
+	Cleanup        bool
 
 	Author Author
 }

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -141,7 +141,10 @@ func (p *Plugin) Execute() error {
 	if err := os.MkdirAll(p.Settings.Repo.WorkDir, os.ModePerm); err != nil {
 		return fmt.Errorf("failed to create working directory: %w", err)
 	}
-	defer os.RemoveAll(p.Settings.Repo.WorkDir)
+
+	if p.Settings.Repo.Cleanup {
+		defer os.RemoveAll(p.Settings.Repo.WorkDir)
+	}
 
 	p.Settings.Repo.IsEmpty, err = plugin_file.IsDirEmpty(p.Settings.Repo.WorkDir)
 	if err != nil {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -151,6 +151,14 @@ func Flags(settings *Settings, category string) []cli.Flag {
 			Destination: &settings.Repo.WorkDir,
 			Category:    category,
 		},
+		&cli.BoolFlag{
+			Name:        "cleanup",
+			Usage:       "delete the working directory after the git action",
+			Sources:     cli.EnvVars("PLUGIN_CLEANUP"),
+			Destination: &settings.Repo.Cleanup,
+			Value:       true,
+			Category:    category,
+		},
 		&cli.StringFlag{
 			Name:        "commit-message",
 			Usage:       "commit message",


### PR DESCRIPTION
# Description

Implements fix for #237 

## Config

It introduces a new config `cleanup`(ENV `PLUGIN_CLEANUP`) with default value set to `true`.
This makes it possible to keep the cloned working directory after the plugin finishes.
The default value ensures backwards compatibility.