### PR TITLE
feat: read commit message from env var

### DIFF
--- a/docs/data/data.yaml
+++ b/docs/data/data.yaml
@@ -83,6 +83,19 @@ properties:
     defaultValue: "[skip ci] commit dirty state"
     required: false
 
+  - name: commit_message_from
+    description: |
+      Read the commit message from the named environment variable.
+
+      Useful for adopting the message of the triggering CI commit (e.g. `CI_COMMIT_MESSAGE` on Woodpecker)
+      without running into YAML substitution and escaping problems for values containing `:` or `"`.
+
+      When set and the named variable resolves to a non-empty value, that value overrides `message`. If
+      the variable is unset or empty, `message` is used as a fallback (either an explicit value or the
+      static default).
+    type: string
+    required: false
+
   - name: netrc_machine
     description: |
       Netrc remote machine name.

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -50,6 +50,16 @@ func (p *Plugin) Validate() error {
 	p.Settings.Repo.Autocorrect = "never"
 	p.Settings.Repo.RemoteName = "origin"
 
+	// If commit-message-from names an environment variable that resolves to a
+	// non-empty value, adopt that value as the commit message. The 'message'
+	// setting (explicit or default) acts as a fallback when the env var is
+	// unset or empty.
+	if p.Settings.CommitMessageFrom != "" {
+		if v := os.Getenv(p.Settings.CommitMessageFrom); v != "" {
+			p.Settings.Repo.CommitMsg = v
+		}
+	}
+
 	if p.Settings.Repo.WorkDir == "" {
 		p.Settings.Repo.WorkDir, err = os.Getwd()
 		if err != nil {

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -55,7 +56,7 @@ func (p *Plugin) Validate() error {
 	// setting (explicit or default) acts as a fallback when the env var is
 	// unset or empty.
 	if p.Settings.CommitMessageFrom != "" {
-		if v := os.Getenv(p.Settings.CommitMessageFrom); v != "" {
+		if v := strings.TrimSpace(os.Getenv(p.Settings.CommitMessageFrom)); v != "" {
 			p.Settings.Repo.CommitMsg = v
 		}
 	}

--- a/plugin/impl_test.go
+++ b/plugin/impl_test.go
@@ -1,0 +1,64 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thegeeklab/wp-git-action/git"
+)
+
+func TestValidate_CommitMessageFrom(t *testing.T) {
+	const ciVar = "TEST_CI_COMMIT_MESSAGE"
+	const staticDefault = "[skip ci] commit dirty state"
+
+	tests := []struct {
+		name              string
+		commitMessageFrom string
+		envValue          string
+		initialMsg        string
+		wantMsg           string
+	}{
+		{
+			name:              "from-flag unset leaves default",
+			commitMessageFrom: "",
+			initialMsg:        staticDefault,
+			wantMsg:           staticDefault,
+		},
+		{
+			name:              "from-flag set but env empty falls back to message",
+			commitMessageFrom: ciVar,
+			envValue:          "",
+			initialMsg:        "scheduled sync",
+			wantMsg:           "scheduled sync",
+		},
+		{
+			name:              "from-flag set and env populated overrides default",
+			commitMessageFrom: ciVar,
+			envValue:          "feat(api): add motion photo facet",
+			initialMsg:        staticDefault,
+			wantMsg:           "feat(api): add motion photo facet",
+		},
+		{
+			name:              "from-flag set and env populated overrides explicit message",
+			commitMessageFrom: ciVar,
+			envValue:          "from CI",
+			initialMsg:        "explicit message",
+			wantMsg:           "from CI",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(ciVar, tt.envValue)
+
+			p := &Plugin{Settings: &Settings{
+				Action:            []string{"commit"},
+				CommitMessageFrom: tt.commitMessageFrom,
+				Repo:              git.Repository{CommitMsg: tt.initialMsg, WorkDir: t.TempDir()},
+			}}
+
+			assert.NoError(t, p.Validate())
+			assert.Equal(t, tt.wantMsg, p.Settings.Repo.CommitMsg)
+		})
+	}
+}

--- a/plugin/impl_test.go
+++ b/plugin/impl_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestValidate_CommitMessageFrom(t *testing.T) {
 	const ciVar = "TEST_CI_COMMIT_MESSAGE"
+
 	const staticDefault = "[skip ci] commit dirty state"
 
 	tests := []struct {

--- a/plugin/impl_test.go
+++ b/plugin/impl_test.go
@@ -19,31 +19,38 @@ func TestValidate_CommitMessageFrom(t *testing.T) {
 		wantMsg           string
 	}{
 		{
-			name:              "from-flag unset leaves default",
+			name:              "commit-message-from unset leaves default",
 			commitMessageFrom: "",
 			initialMsg:        staticDefault,
 			wantMsg:           staticDefault,
 		},
 		{
-			name:              "from-flag set but env empty falls back to message",
+			name:              "commit-message-from set but env empty falls back to message",
 			commitMessageFrom: ciVar,
 			envValue:          "",
 			initialMsg:        "scheduled sync",
 			wantMsg:           "scheduled sync",
 		},
 		{
-			name:              "from-flag set and env populated overrides default",
+			name:              "commit-message-from set and env populated overrides default",
 			commitMessageFrom: ciVar,
 			envValue:          "feat(api): add motion photo facet",
 			initialMsg:        staticDefault,
 			wantMsg:           "feat(api): add motion photo facet",
 		},
 		{
-			name:              "from-flag set and env populated overrides explicit message",
+			name:              "commit-message-from set and env populated overrides explicit message",
 			commitMessageFrom: ciVar,
 			envValue:          "from CI",
 			initialMsg:        "explicit message",
 			wantMsg:           "from CI",
+		},
+		{
+			name:              "commit-message-from set but env is whitespace falls back to message",
+			commitMessageFrom: ciVar,
+			envValue:          "  \n\t  ",
+			initialMsg:        "scheduled sync",
+			wantMsg:           "scheduled sync",
 		},
 	}
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -171,7 +171,7 @@ func Flags(settings *Settings, category string) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "commit-message-from",
-			Usage:       "read the commit message from the named environment variable (e.g. CI_COMMIT_MESSAGE) when 'commit-message' is not explicitly set",
+			Usage:       "name of an environment variable to read the commit message from",
 			Sources:     cli.EnvVars("PLUGIN_COMMIT_MESSAGE_FROM"),
 			Destination: &settings.CommitMessageFrom,
 			Category:    category,

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -21,6 +21,8 @@ type Settings struct {
 	Action []string
 	SSHKey string
 
+	CommitMessageFrom string
+
 	Netrc Netrc
 	Pages Pages
 	Repo  git.Repository
@@ -165,6 +167,13 @@ func Flags(settings *Settings, category string) []cli.Flag {
 			Sources:     cli.EnvVars("PLUGIN_MESSAGE"),
 			Destination: &settings.Repo.CommitMsg,
 			Value:       "[skip ci] commit dirty state",
+			Category:    category,
+		},
+		&cli.StringFlag{
+			Name:        "commit-message-from",
+			Usage:       "read the commit message from the named environment variable (e.g. CI_COMMIT_MESSAGE) when 'commit-message' is not explicitly set",
+			Sources:     cli.EnvVars("PLUGIN_COMMIT_MESSAGE_FROM"),
+			Destination: &settings.CommitMessageFrom,
 			Category:    category,
 		},
 		&cli.BoolFlag{


### PR DESCRIPTION
The `message` setting accepts a static string or a Woodpecker-substituted `${CI_COMMIT_MESSAGE}`. Substitution happens textually before YAML parsing, so messages containing characters that are meaningful to the YAML parser break the pipeline:

- A literal `:` (every conventional commit, e.g. `fix(api): …`) triggers a `mapping values are not allowed in this context` parse error.
- Quoting around the substitution (`message: "${CI_COMMIT_MESSAGE}"`) handles `:` but breaks on a literal `"` in the message. Single-quoting has the same flaw for `'`.

This PR adds an opt-in `commit-message-from` setting that names an environment variable from which the plugin reads the commit message at runtime, completely bypassing the YAML substitution path:

```yaml
settings:
  action: [commit, push]
  commit-message-from: CI_COMMIT_MESSAGE
```

Semantics:

- If `commit-message-from` is set and the named env var resolves to a non-empty value, that value is used. It overrides both an explicit `message` setting and the static default.
- Otherwise (`commit-message-from` unset, or env var unset/empty), `message` is used as today — either its explicit value or the static default `"[skip ci] commit dirty state"`.

The existing `Sources: cli.EnvVars("PLUGIN_AUTHOR_NAME", "CI_COMMIT_AUTHOR")` fallback pattern for `author_name`/`author_email` was deliberately not used here for `message`: doing so would silently shadow the static `"[skip ci] commit dirty state"` default in any Woodpecker context (where `CI_COMMIT_MESSAGE` is always set) and would be a breaking change to the plugin's defaults.

### Motivation

In [opencloud-eu/libre-graph-api#48](https://github.com/opencloud-eu/libre-graph-api/pull/48) we hit the YAML substitution problem on multiple pipelines and currently work around it by quoting `${CI_COMMIT_MESSAGE}` in YAML. That fix only covers `:`, not `"`; we kept it as the lesser evil but would much rather drop the workaround entirely with a clean plugin-level solution. With this PR, the consumer pipeline becomes simply `commit-message-from: CI_COMMIT_MESSAGE`.

### Changes

- New `commit-message-from` string flag (`PLUGIN_COMMIT_MESSAGE_FROM`).
- `Validate()` overrides `Repo.CommitMsg` from the named env var when it resolves to a non-empty value.
- Unit tests covering all four branches (flag unset / env empty falls back to message / env populated overrides default / env populated overrides explicit message).
- Docs entry in `docs/data/data.yaml`.
